### PR TITLE
OLTU-134 Minor improvements in build

### DIFF
--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.oltu</groupId>
     <artifactId>org.apache.oltu.parent</artifactId>
-    <version>1</version>
+    <version>3-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,6 +22,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>10</version>
+    <relativePath />
   </parent>
 
   <groupId>org.apache.oltu</groupId>
@@ -604,6 +605,7 @@
             <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
           </instructions>
         </configuration>
+        <extensions>true</extensions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Since metadata is generally speaking valid I just changed packaging. Now build goes just fine, however there are some minor issues with split packages. This means same package name is used in dependency and project which depends on it. To avoid this issue each project must have unique name and package contents can not be split into two places (ie. oltu commons).
