### PR TITLE
Fixed bug with JWTParser when parsing the expiration

### DIFF
--- a/oauth-2.0/jwt/src/main/java/org/apache/oltu/oauth2/jwt/io/JWTClaimsSetParser.java
+++ b/oauth-2.0/jwt/src/main/java/org/apache/oltu/oauth2/jwt/io/JWTClaimsSetParser.java
@@ -34,9 +34,17 @@ final class JWTClaimsSetParser extends CustomizableEntityReader<JWT, JWT.Builder
         if (AUDIENCE.equals(key)) {
             handleAudience(value);
         } else if (EXPIRATION_TIME.equals(key)) {
-            getBuilder().setClaimsSetExpirationTime(((Integer) value).longValue());
+            if (value instanceof Long) {
+                getBuilder().setClaimsSetExpirationTime((Long) value);
+            } else {
+                getBuilder().setClaimsSetExpirationTime(((Integer) value).longValue());
+            }
         } else if (ISSUED_AT.equals(key)) {
-            getBuilder().setClaimsSetIssuedAt(((Integer) value).longValue());
+            if (value instanceof Long) {
+                getBuilder().setClaimsSetIssuedAt((Long) value);
+            } else {
+                getBuilder().setClaimsSetIssuedAt(((Integer) value).longValue());
+            }
         } else if (ISSUER.equals(key)) {
             getBuilder().setClaimsSetIssuer(String.valueOf(value));
         } else if (JWT_ID.equals(key)) {


### PR DESCRIPTION
I am implementing a oauth server and ran into an error. Really you should never want to convert a Long into an Integer then back into a long. Hopefully I haven't broken any kind of etiquette in doing this. Please accept/release this hotfix. Thanks.
