### PR TITLE
Fix validator for authorization code and implicit grants

### DIFF
--- a/oauth-2.0/authzserver/src/main/java/org/apache/oltu/oauth2/as/validator/AuthorizationCodeValidator.java
+++ b/oauth-2.0/authzserver/src/main/java/org/apache/oltu/oauth2/as/validator/AuthorizationCodeValidator.java
@@ -35,7 +35,6 @@ public class AuthorizationCodeValidator extends AbstractValidator<HttpServletReq
     public AuthorizationCodeValidator() {
         requiredParams.add(OAuth.OAUTH_GRANT_TYPE);
         requiredParams.add(OAuth.OAUTH_CODE);
-        requiredParams.add(OAuth.OAUTH_REDIRECT_URI);
 
         enforceClientAuthentication = true;
     }

--- a/oauth-2.0/authzserver/src/main/java/org/apache/oltu/oauth2/as/validator/TokenValidator.java
+++ b/oauth-2.0/authzserver/src/main/java/org/apache/oltu/oauth2/as/validator/TokenValidator.java
@@ -38,7 +38,6 @@ public class TokenValidator extends AbstractValidator<HttpServletRequest> {
     public TokenValidator() {
         requiredParams.add(OAuth.OAUTH_RESPONSE_TYPE);
         requiredParams.add(OAuth.OAUTH_CLIENT_ID);
-        requiredParams.add(OAuth.OAUTH_REDIRECT_URI);
     }
 
     @Override


### PR DESCRIPTION
Per the OAuth 2.0 specs, redirect_uri is not required as part of the authorization code and implicit grants.

Authorization Code Grant
https://tools.ietf.org/html/rfc6749#section-4.1.1
" redirect_uri
         OPTIONAL.  As described in Section 3.1.2."

Implicit Grant 
https://tools.ietf.org/html/rfc6749#section-4.2.1
"redirect_uri
         OPTIONAL.  As described in Section 3.1.2."
