### PR TITLE
JWT - allow empty string signature for algorithm none

### DIFF
--- a/commons/encodedtoken/src/main/java/org/apache/oltu/commons/encodedtoken/TokenReader.java
+++ b/commons/encodedtoken/src/main/java/org/apache/oltu/commons/encodedtoken/TokenReader.java
@@ -27,7 +27,7 @@ public abstract class TokenReader<T> extends TokenDecoder {
     /**
      * The Base64 JSON string default separator.
      */
-    private final Pattern base64urlTokenPattern = Pattern.compile("([a-zA-Z0-9-​_=]+)\\.([a-zA-Z0-9-_​=]+)\\.([a-zA-Z0-9-_=]+)");
+    private final Pattern base64urlTokenPattern = Pattern.compile("^([a-zA-Z0-9-​_=]+)\\.([a-zA-Z0-9-_​=]+)\\.([a-zA-Z0-9-_=]+)?$");
 
     /**
      * Read the base64url token string

--- a/commons/encodedtoken/src/test/java/org/apache/oltu/commons/encodedtoken/TokenReaderTest.java
+++ b/commons/encodedtoken/src/test/java/org/apache/oltu/commons/encodedtoken/TokenReaderTest.java
@@ -36,6 +36,20 @@ public class TokenReaderTest {
         String accessToken = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw";
         Assert.assertNotNull(tokenReader.read(accessToken));
     }
+
+    @Test
+    public void test_read_alg_none() {
+        tokenReader = new TokenReader<String>() {
+            protected String build(String rawString, String decodedHeader,
+                                   String decodedBody, String encodedSignature) {
+
+                return "";
+            }
+        };
+
+        String accessToken = "eyJhbGciOiJub25lIn0K.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.";
+        Assert.assertNotNull(tokenReader.read(accessToken));
+    }
     
     @Test
     public void test_read2() {

--- a/oauth-2.0/jwt/src/main/java/org/apache/oltu/oauth2/jwt/io/JWTWriter.java
+++ b/oauth-2.0/jwt/src/main/java/org/apache/oltu/oauth2/jwt/io/JWTWriter.java
@@ -36,7 +36,7 @@ public final class JWTWriter extends TokenWriter<JWT> {
 
     @Override
     protected String writeSignature(JWT token) {
-        return token.getSignature();
+        return token.getSignature() == null ? "" : token.getSignature();
     }
 
 }

--- a/oauth-2.0/jwt/src/test/java/org/apache/oltu/oauth2/jwt/io/IOTestCaseConstants.java
+++ b/oauth-2.0/jwt/src/test/java/org/apache/oltu/oauth2/jwt/io/IOTestCaseConstants.java
@@ -50,4 +50,9 @@ interface IOTestCaseConstants {
                             + "7MxUgVEgh8G-Nnbk_baJ6k_3w5c1SKFamFiHHDoKLFhrt1Y8JKSuGwE02V-px4Cn0dRAQAc1IN5C"
                             + "U6wqCrYK0p-fv_fvy28";
 
+    public final String JWT_ALG_NONE = "eyJhbGciOiJub25lIn0"
+                            + "."
+                            + "eyJleHAiOjEzNjY3MzAyMTcsImlhdCI6MTM2NjcyNjMxNywiaWQiOiIxMDY0MjI0NTMwODI0Nzk5OTg0MjkifQ"
+                            + ".";
+
 }

--- a/oauth-2.0/jwt/src/test/java/org/apache/oltu/oauth2/jwt/io/JWTWriterTestCase.java
+++ b/oauth-2.0/jwt/src/test/java/org/apache/oltu/oauth2/jwt/io/JWTWriterTestCase.java
@@ -106,4 +106,19 @@ public final class JWTWriterTestCase implements IOTestCaseConstants {
         assertEquals(JWT_MULTIPLE_AUDIENCES, encodedJWT);
     }
 
+    @Test
+    public void writeWithAlgNone() {
+        JWT jwt = new JWT.Builder()
+                          // header
+                          .setHeaderAlgorithm("none")
+                          // claimset
+                          .setClaimsSetExpirationTime(1366730217L)
+                          .setClaimsSetIssuedAt(1366726317L)
+                          .setClaimsSetCustomField("id", "106422453082479998429")
+                          // no signature
+                          .build();
+        String encodedJWT = new JWTWriter().write(jwt);
+        assertEquals(JWT_ALG_NONE, encodedJWT);
+    }
+
 }


### PR DESCRIPTION
For JWTs using algorithm `none`, the signature should be an empty string.
https://tools.ietf.org/html/rfc7519#page-12